### PR TITLE
Made the examples link more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Alertify is an unobtrusive customizable JavaScript notification system.
 * Callback parameter handling both OK and Cancel button clicks
 * Chaining which allows queued dialogs
 
+## Examples
+
+http://fabien-d.github.com/alertify.js/
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
Edited README.md to add the example link more obvious.

I did not see it at first, seems like a few others on HN didn't either.
