### PR TITLE
Made message optional

### DIFF
--- a/lib/alertify.js
+++ b/lib/alertify.js
@@ -312,7 +312,7 @@
 		/**
 		 * Create a dialog box
 		 * 
-		 * @param  {String}   message    The message passed from the callee
+		 * @param  {String}   message    [Optional] The message passed from the callee
 		 * @param  {String}   type       Type of dialog to create
 		 * @param  {Function} fn         [Optional] Callback function
 		 * 
@@ -326,7 +326,6 @@
 				else check();
 			};
 			// error catching
-			if (typeof message !== "string") throw new Error("message must be a string");
 			if (typeof type !== "string") throw new Error("type must be a string");
 			if (typeof fn !== "undefined" && typeof fn !== "function") throw new Error("fn must be a function");
 			// initialize alertify if it hasn't already been done


### PR DESCRIPTION
This PR is more of a conversation starter. Should message be required? Are we trying to replicate the functionality of the browser dialogs? If so, IMO empty messages should not throw an error, as they currently do. They should display undefined.

This is related to Issue #24.
