### PR TITLE
Fix buttons hover with Bootstrap on the page

### DIFF
--- a/themes/alertify.bootstrap.css
+++ b/themes/alertify.bootstrap.css
@@ -85,6 +85,8 @@
 				}
 				.alertify-button-cancel:hover {
 					background: #E6E6E6;
+					color: #333;
+					text-decoration: none;
 				}
 				.alertify-button-ok {
 					text-shadow: 0 -1px 0 rgba(0,0,0,.25);
@@ -96,6 +98,8 @@
 				}
 				.alertify-button-ok:hover {
 					background: #04C;
+					color: #FFF;
+					text-decoration: none;
 				}
 
 .alertify-log {


### PR DESCRIPTION
When Twitter Bootstrap is added to the page
it adds some styles which interfere with this theme.

Namely:
    a:hover {
        color: #005580;
        text-decoration: underline;
    }

This caused the hover states of the ok/cancel buttons
to have a blue color and an underline, which is not right.
