### PR TITLE
Add support for Composer & publish to Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+  "name": "components/alertify-js",
+  "description": "browser dialogs never looked so good",
+  "type": "component",
+  "keywords": ["alert", "javascript", "growl"],
+  "homepage": "http://fabien-d.github.io/alertify.js/",
+  "license": "MIT",
+  "support": {
+    "issues": "https://github.com/fabien-d/alertify.js/issues",
+    "wiki": "https://github.com/fabien-d/alertify.js/wiki",
+    "source": "https://github.com/fabien-d/alertify.js"
+  },
+  "authors": [
+    {
+      "name": "Fabien Doiron",
+      "email": "fabien.doiron@gmail.com",
+      "homepage": "http://fabien-d.github.io/"
+    }
+  ],
+  "require": {
+    "robloach/component-installer": "*"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "js/alertify.js"
+      ],
+      "styles": [
+        "css/alertify.css"
+      ],
+      "files": [
+        "js/alertify.min.js",
+        "css/alertify.core.css",
+        "css/alertify.default.css",
+        "css/alertify.bootstrap.css"
+      ]
+    }
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
-  "name": "components/alertify-js",
+  "name": "components/alertify.js",
   "description": "browser dialogs never looked so good",
+  "version": "0.3.9",
   "type": "component",
   "keywords": ["alert", "javascript", "growl"],
   "homepage": "http://fabien-d.github.io/alertify.js/",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "components/alertify.js",
   "description": "browser dialogs never looked so good",
-  "version": "0.3.9",
+  "version": "0.4.0rc1",
   "type": "component",
   "keywords": ["alert", "javascript", "growl"],
   "homepage": "http://fabien-d.github.io/alertify.js/",
@@ -24,16 +24,17 @@
   "extra": {
     "component": {
       "scripts": [
-        "js/alertify.js"
+        "dist/alertify.js"
       ],
       "styles": [
-        "css/alertify.css"
+        "dist/themes/alertify.css",
+        "dist/themes/alertify.default.css"
       ],
       "files": [
-        "js/alertify.min.js",
-        "css/alertify.core.css",
-        "css/alertify.default.css",
-        "css/alertify.bootstrap.css"
+        "dist/alertify.min.js",
+        "dist/themes/alertify.css",
+        "dist/themes/alertify.default.css",
+        "dist/themes/alertify.bootstrap.css"
       ]
     }
   }


### PR DESCRIPTION
See #149

I have only recently started using Composer and before today I have not prepared a component for publishing on Packagist. However, the following `composer.json` does clone the alertify.js repository into `components\alertify.js` directory:

``` json
{
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/andrew-kzoo/alertify.js"
    }
  ],
  "require": {
    "components/alertify.js": "dev-master"
  }
}
```

Publishing to Packagist is straightforward. Few, if any, additional changes to `composer.json` should be necessary. http://getcomposer.org/doc/02-libraries.md#publishing-to-packagist
