### PR TITLE
fix for #152: allow users to style dialog types individually (second try) 

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -247,7 +247,7 @@ define(["alertify", "proto", "element", "validate", "transition", "keys"], funct
             }
             dialog.el.innerHTML    = build(item);
             dialog.cover.className = clsCoverShow;
-            dialog.el.className    = clsElShow;
+            dialog.el.className    = clsElShow + " " + "alertify-" + item.type;
 
             controls.reset  = Alertify.get("alertify-resetFocus");
             controls.ok     = Alertify.get("alertify-ok")     || undefined;


### PR DESCRIPTION
(this is a fixed version of my earlier pull-request (#153))

Added a class `alertify-<type>` to dialog. This way, the user can style one type of dialog different from the others: 

```
.alertify-dialog {
  background-color: red;
  padding: 25px; 
}
.alertify-dialog-confirm,
.alertify-dialog-prompt {
  background-color: blue;
}
```
