### PR TITLE
Simplify the example page to the bare minimum

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-jshint");
     grunt.loadNpmTasks("grunt-contrib-qunit");
     grunt.loadNpmTasks("grunt-contrib-clean");
+    grunt.loadNpmTasks("grunt-contrib-connect");
     grunt.loadNpmTasks("grunt-contrib-requirejs");
     grunt.loadNpmTasks("grunt-contrib-copy");
     grunt.loadNpmTasks("grunt-contrib-uglify");
@@ -42,6 +43,15 @@ module.exports = function (grunt) {
                     cssDir: "dist/themes",
                     environment: "production",
                     outputStyle: "nested"
+                }
+            }
+        },
+        connect: {
+            server: {
+                options: {
+                    port: 9001,
+                    keepalive: true,
+                    base: ''
                 }
             }
         },

--- a/example/index.html
+++ b/example/index.html
@@ -2,375 +2,43 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>alertify.js - browser dialogs never looked so good</title>
-    <link rel="stylesheet" href="assets/css/main.css" />
+    <title>alertify.js - example page</title>
     <link rel="stylesheet" href="../dist/themes/alertify.css" />
     <link rel="stylesheet" href="../dist/themes/alertify.default.css" id="toggleCSS" />
-    <link rel="stylesheet" href="assets/js/lib/sh/shCore.css" />
-    <link rel="stylesheet" href="assets/js/lib/sh/shCoreDefault.css" />
-    <link href="http://fonts.googleapis.com/css?family=Lato:400,900" rel="stylesheet" type="text/css">
     <meta name="viewport" content="width=device-width">
-    <script>
-        // ensure legacy browsers support html5 tags
-        // could include a shim or modernizr or...
-        // this is a quick workaround for the time being
-        document.createElement("nav");
-        document.createElement("header");
-        document.createElement("article");
-        document.createElement("section");
-        document.createElement("footer");
-    </script>
+    <style>
+        .is-disabled {
+            color: #999;
+        }
+    </style>
 </head>
 <body>
-    <header class="masthead">
-        <div class="container">
-            <p class="mh-logo">alertify<span class="extension">.js</span></p>
-            <h1>browser dialogs never<br />looked so good</h1>
-            <a href="https://github.com/fabien-d/alertify.js"><img style="position: fixed; z-index: 5000; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
-            <img src="assets/img/dialogs.png" alt="Native browser dialogs versus alertify.js dialogs" width="808" height="210" />
-        </div>
-    </header>
 
-    <h2><span>download alertify.js 0.4.0rc1</span></h2>
-    <section class="block">
-        <div class="container">
-            <div class="cta">
-                <a class="button-primary" href="https://github.com/fabien-d/alertify.js/tree/0.4.0rc1">Source Code <span class="small">(GitHub)</span></a>
-            </div>
-        </div>
-    </section>
+    <h2>Dialogs</h2>
+    <a href="#" id="alert">Alert Dialog</a><br>
+    <a href="#" id="confirm">Confirm Dialog</a><br>
+    <a href="#" id="prompt">Prompt Dialog</a><br>
+    <a href="#" id="labels">Custom Labels</a><br>
+    <a href="#" id="focus">Button Focus</a><br>
+    <a href="#" id="order">Button Order</a>
 
-    <h2><span>features</span></h2>
-    <section class="block">
-        <div class="container">
-            <div class="row">
-                <div class="media feature">
-                    <div class="mediaAside"><i class="icon-pencil"></i></div>
-                    <div class="mediaBody">
-                        <h3>Customizable look and feel</h3>
-                        <p>If you can edit CSS you can customize the look of alertify.js to match your needs</p>
-                    </div>
-                </div>
-                <div class="media feature alt">
-                    <div class="mediaAside"><i class="icon-ok"></i></div>
-                    <div class="mediaBody">
-                        <h3>Lightweight, no dependencies</h3>
-                        <p>No matter the type of project, if JavaScript is available alertify.js can be used</p>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="media feature">
-                    <div class="mediaAside"><i class="icon-bullhorn"></i></div>
-                    <div class="mediaBody">
-                        <h3>Growl-like notification</h3>
-                        <p>Unobtrusive notification messages can be used to give feedback to users or even as a console.log replacement</p>
-                    </div>
-                </div>
-                <div class="media feature alt">
-                    <div class="mediaAside"><i class="icon-laptop"></i></div>
-                    <div class="mediaBody">
-                        <h3>Cross-browser and platform</h3>
-                        <p>Whether you use a desktop, laptop, tablet or mobile device, alertify.js has you covered</p>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="media feature">
-                    <div class="mediaAside"><i class="icon-star"></i></div>
-                    <div class="mediaBody">
-                        <h3>Simple API</h3>
-                        <p>From callbacks to handle OK and Cancel actions to customizable properties, using alertify.js is very straightforward<br />
-                        <a href="https://github.com/fabien-d/alertify.js/wiki/API-Documentation">Read full documentation</a></p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
+    <h2>Logs</h2>
+    <a href="#" id="info">Standard Log</a><br>
+    <a href="#" id="success">Success Log</a><br>
+    <a href="#" id="error">Error Log</a><br>
+    <a href="#" id="delay">Hide in 10 seconds</a><br>
+    <a href="#" id="forever">Persistent Log</a>
 
-    <h2><span>default dialogs</span></h2>
-    <section class="usage">
-        <section class="block">
-            <div class="container">
-                <h3>Default dialogs</h3>
-                <section class="block">
-                    <p><pre class="brush:javascript">
-                        /**
-                         * Alertify Alert Dialog
-                         *
-                         * @param  {String}   Dialog message
-                         * @param  {Function} [Optional] Callback after OK
-                         * @return {Object}   Dialog Object
-                         */
-                        Alertify.dialog.alert("Message");
+    <h3>API Driven Log</h3>
+    <a href="#" id="notiAPI">Create Log</a><br>
+    <a href="#" class="is-disabled" id="closeAPI">Close Log</a><br>
+    <a href="#" class="is-disabled" id="recreateAPI">Recreate Log</a><br>
+    <a href="#" class="is-disabled" id="reshowAPI">Reshow Log</a>
 
-                        // Alertify.dialog can be stored in a variable
-                        // var d = Alertify.dialog;
-                        // d.alert("Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="alert">Alert Dialog</a>
-                    </nav>
-                </section>
-
-                <section class="block">
-                    <p><pre class="brush:javascript">
-                        /**
-                         * Alertify Confirm Dialog
-                         *
-                         * @param  {String}   Dialog message
-                         * @param  {Function} [Optional] Callback after OK
-                         * @param  {Function} [Optional] Callback after Cancel
-                         * @return {Object}   Dialog Object
-                         */
-                        Alertify.dialog.confirm("Message", function () {
-                            // user clicked "ok"
-                        }, function () {
-                            // user clicked "cancel"
-                        });
-
-                        // Alertify.dialog can be stored in a variable
-                        // var d = Alertify.dialog;
-                        // d.confirm("Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="confirm">Confirm Dialog</a>
-                    </nav>
-                </section>
-
-                <section class="block">
-                    <p><pre class="brush:javascript">
-                        /**
-                         * Alertify Prompt Dialog
-                         *
-                         * @param  {String}   Dialog message
-                         * @param  {Function} [Optional] Callback after OK
-                         * @param  {Function} [Optional] Callback after Cancel
-                         * @param  {String}   [Optional] Default placeholder text
-                         * @return {Object}   Dialog Object
-                         */
-                        Alertify.dialog.prompt("Message", function (str) {
-                            // str is the input text
-                            // user clicked "ok"
-                        }, function () {
-                            // user clicked "cancel"
-                        }, "Default Value");
-
-                        // Alertify.dialog can be stored in a variable
-                        // var d = Alertify.dialog;
-                        // d.prompt("Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="prompt">Prompt Dialog</a>
-                    </nav>
-                </section>
-            </div>
-        </section>
-    </section>
-
-    <h2><span>default logs</span></h2>
-    <section class="usage">
-        <section class="block">
-            <div class="container">
-                <h3>Default Notifications</h3>
-
-                <section class="block">
-                    <p><pre class="brush:javascript">
-                        /**
-                         * Alertify Log
-                         *
-                         * @param  {String}   Log type
-                         * @param  {String}   Log message
-                         * @param  {Number}   [Optional] Delay in ms, 0 means persistent
-                         * @return {Object}   Log Object
-                         */
-                        Alertify.log.create("info", "Notification");
-
-                        // Alertify.log can be stored in a variable
-                        // var l = Alertify.log;
-                        // l.create("info", "Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="notification">Create Log</a>
-                    </nav>
-                </section>
-
-                <section class="block">
-                    <h4>Info Log</h4>
-                    <p><pre class="brush:javascript">
-                        /**
-                         * Alertify Info Log
-                         *
-                         * @param  {String}   Log message
-                         * @param  {Number}   [Optional] Delay in ms, 0 means persistent
-                         * @return {Object}   Log Object
-                         */
-                        Alertify.log.info("Notification");
-
-                        // Alertify.log can be stored in a variable
-                        // var l = Alertify.log;
-                        // l.info("Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="info">Standard Log</a>
-                    </nav>
-                </section>
-
-                <section class="block">
-                    <h4>Success Log</h4>
-                    <p><pre class="brush:javascript">
-                        /**
-                         * Alertify Success Log
-                         * shorthand for Alertify.log.create("success", "Notification");
-                         *
-                         * @param  {String}   Log message
-                         * @param  {Number}   [Optional] Delay in ms, 0 means persistent
-                         * @return {Object}   Log Object
-                         */
-                        Alertify.log.success("Success notification");
-
-                        // Alertify.log can be stored in a variable
-                        // var l = Alertify.log;
-                        // l.success("Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="success">Success Log</a>
-                    </nav>
-                </section>
-
-                <section class="block">
-                    <h4>Error Log</h4>
-                    <p><pre class="brush:javascript">
-                        /**
-                         * Alertify Error Log
-                         * shorthand for Alertify.log.create("error", "Notification");
-                         *
-                         * @param  {String}   Log message
-                         * @param  {Number}   [Optional] Delay in ms, 0 means persistent
-                         * @return {Object}   Log Object
-                         */
-                        Alertify.log.error("Error notification");
-
-                        // Alertify.log can be stored in a variable
-                        // var l = Alertify.log;
-                        // l.error("Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="error">Error Log</a>
-                    </nav>
-                </section>
-
-                <section class="block">
-                    <h4>Storing Log Element</h4>
-                    <p><pre class="brush:javascript">
-                        // Storing log element
-                        var myLog = Alertify.log.create("custom", "stored notification");
-                        // myLog API
-                        myLog.close();  // closes the log element
-                        myLog.create(); // recreates (doesn't show) the closed log element
-                        myLog.show();   // show the recreated log element
-                        </pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="notiAPI">API Driven Log</a>
-                        <a class="button-primary is-disabled" href="#" id="closeAPI">Close API Driven Log</a>
-                        <a class="button-primary is-disabled" href="#" id="recreateAPI">Recreate Driven Log</a>
-                        <a class="button-primary is-disabled" href="#" id="reshowAPI">Reshow Driven Log</a>
-                    </nav>
-                </section>
-
-                <section class="block">
-                    <p><pre class="brush:javascript">
-                        Alertify.log.info("Hiding in 10 secs", 10000);
-                        Alertify.log.info("Will stay until clicked", 0);
-
-                        // Alertify.log can be stored in a variable
-                        // var l = Alertify.log;
-                        // l.info("Message");</pre></p>
-                    <nav class="button-group">
-                        <a class="button-primary" href="#" id="delay">Hide in 10 seconds</a>
-                        <a class="button-primary" href="#" id="forever">Persistent Log</a>
-                    </nav>
-                </section>
-            </div>
-        </section>
-
-        <h2><span>customizable properties</span></h2>
-
-        <section class="block">
-            <div class="container">
-                <h3>Button Labels</h3>
-                <p><pre class="brush:javascript">
-                    // custom OK and Cancel label
-                    // default: "OK", "Cancel"
-                    Alertify.dialog.labels.ok = "Accept";
-                    Alertify.dialog.labels.cancel = "Deny";
-                    // button labels will be "Accept" and "Deny"
-                    Alertify.dialog.confirm("Message");</pre></p>
-                <nav class="button-group">
-                    <a class="button-primary" href="#" id="labels">Custom Labels</a>
-                </nav>
-            </div>
-        </section>
-
-        <section class="block">
-            <div class="container">
-                <h3>Button Focus</h3>
-                <p><pre class="brush:javascript">
-                    // which button receives focus
-                    // default: "ok"
-                    Alertify.dialog.buttonFocus = "cancel"; // "none", "ok", "cancel"
-                    // focus will be given to the cancel button
-                    Alertify.dialog.confirm("Message");</pre></p>
-                <nav class="button-group">
-                    <a class="button-primary" href="#" id="focus">Button Focus</a>
-                </nav>
-            </div>
-        </section>
-
-        <section class="block">
-            <div class="container">
-                <h3>Button Order</h3>
-                <p><pre class="brush:javascript">
-                    // order of the buttons
-                    // default: Cancel, OK
-                    Alertify.dialog.buttonReverse = true;
-                    // buttons order will be OK, Cancel
-                    Alertify.dialog.confirm("Message");</pre></p>
-                <nav class="button-group">
-                    <a class="button-primary" href="#" id="order">Button Order</a>
-                </nav>
-            </div>
-        </section>
-
-        <h2><span>custom themes</span></h2>
-        <section class="block">
-            <div class="container">
-                <p><pre class="brush:javascript">
-                    // bootstrap theme
-                    // use bootstrap theme CSS
-                    // themes/alertify.bootstrap.css
-                    Alertify.dialog.prompt("message", ...);</pre></p>
-
-                <nav class="button-group">
-                    <a class="button-primary" href="#" id="bootstrap">Bootstrap Theme</a>
-                </nav>
-            </div>
-        </section>
-    </section>
-
-    <footer class="footer">
-        <div class="container">
-            <p><a href="http://github.com/fabien-d/alertify.js/issues">Report an issue</a> | <a href="http://github.com/fabien-d/alertify.js">View on GitHub</a> | Follow Me on <a href="http://www.github.com/fabien-d"><i class="icon-github"></i>GitHub</a> and <a href="http://www.twitter.com/fabien_doiron"><i class="icon-twitter"></i>Twitter</a></p>
-            <p><iframe style="border: 0; margin: 0; padding: 0;" src="https://www.gittip.com/fabien-d/widget.html" width="48pt" height="22pt"></iframe></p>
-            <p>alertify.js is licensed under <a href="http://www.opensource.org/licenses/MIT">MIT</a>, copyright &copy; Fabien Doiron</p>
-
-            <ul class="featured-list">
-                <li><a href="http://blog.teamtreehouse.com/explaining-css-landing-pages-treehouse-show-ep-22" class="treehouse">The Treehouse Show, Ep. 22</a></li>
-                <li><a href="http://www.webdevradio.com/?id=131" class="webdev">webdev radio, Ep. 105</a></li>
-            </ul>
-        </div>
-    </footer>
+    <h2>Themes</h2>
+    <a href="#" id="bootstrap">Bootstrap Theme</a>
 
     <script src="../dist/alertify.min.js"></script>
-    <script src="assets/js/lib/sh/shCore.js"></script>
-    <script src="assets/js/lib/sh/shBrushJScript.js"></script>
-    <script>
-        SyntaxHighlighter.all()
-    </script>
-
     <script>
         "use strict";
         var
@@ -417,12 +85,6 @@
 
         // ==============================
         // Standard Dialogs
-        $("notification").onclick = function () {
-            reset();
-            l.create("info", "Standard log message");
-            return false;
-        };
-
         var logAPI,
             canCreate   = true,
             canClose    = false,
@@ -434,8 +96,8 @@
                 logAPI = logAPI || l.info("API driven log", 0);
                 canCreate = false;
                 canClose  = true;
-                this.className = "button-primary is-disabled";
-                $("closeAPI").className = "button-primary";
+                this.className = "is-disabled";
+                $("closeAPI").className = "";
             }
             return false;
         };
@@ -445,8 +107,8 @@
                 logAPI.close();
                 canClose    = false;
                 canRecreate = true;
-                this.className = "button-primary is-disabled";
-                $("recreateAPI").className = "button-primary";
+                this.className = "is-disabled";
+                $("recreateAPI").className = "";
             }
             return false;
         };
@@ -456,8 +118,8 @@
                 logAPI.create();
                 canRecreate = false;
                 canReshow   = true;
-                this.className = "button-primary is-disabled";
-                $("reshowAPI").className = "button-primary";
+                this.className = "is-disabled";
+                $("reshowAPI").className = "";
             }
             return false;
         };
@@ -467,8 +129,8 @@
                 logAPI.show();
                 canReshow = false;
                 canClose  = true;
-                this.className = "button-primary is-disabled";
-                $("closeAPI").className = "button-primary";
+                this.className = "is-disabled";
+                $("closeAPI").className = "";
             }
             return false;
         };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "grunt-contrib-copy": "~0.4.0",
     "grunt-contrib-uglify": "~0.1.1",
     "requirejs": "~2.1.4",
-    "grunt-contrib-compass": "~0.1.1"
+    "grunt-contrib-compass": "~0.1.1",
+    "grunt-contrib-connect": "~0.3.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
Remove all unnecessary details from the example page and left only the bare minimum. Also included a `grunt connect` task which allows the example site to run at `http://localhost:9001/example`
