### PR TITLE
Update alertify.default.css

### DIFF
--- a/themes/alertify.core.css
+++ b/themes/alertify.core.css
@@ -129,13 +129,10 @@
 
 /* ========================================================================== */
 /* States */
+.alertify-hidden,
 .alertify--alert .alertify-button-cancel,
 .alertify--alert .alertify-input,
 .alertify--confirm .alertify-input {
-    display: none;
-}
-
-.alertify-hidden {
     display: none;
 }
 

--- a/themes/alertify.default.css
+++ b/themes/alertify.default.css
@@ -8,13 +8,14 @@
 }
 .alertify-body {
     background: #ecf0f1;
-    background: rgba(236, 240, 241, 0.9);
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#E6ECF0F1,endColorstr=#E6ECF0F1);
+    background: rgba(236, 240, 241, 0.85);
+    box-shadow: 0 0.125em 1em rgba(0, 0, 0, 0.6);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#D9ECF0F1,endColorstr=#D9ECF0F1);
 }
 .alertify-title {
     background: #34495e;
-    background: rgba(52, 73, 94, 0.9);
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#E634495E,endColorstr=#E634495E);
+    background: rgba(52, 73, 94, 0.85);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#D934495E,endColorstr=#D934495E);
     margin: 0;
     padding: 2em;
     font-size: 1.1em;
@@ -58,7 +59,15 @@
 }
 .alertify-button:focus { outline: none }
 .alertify-button-ok, .alertify-button-cancel { color: #eeeeee }
-.alertify-button-ok { background-color: #60db94 }
+.alertify-button-ok {
+    background: #45d582;
+    background: rgba(69, 213, 130, 0.85);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#D945D582,endColorstr=#D945D582);
+}
 .alertify-button-ok:hover, .alertify-button-ok:active, .alertify-button-ok:focus { background-color: #27ae60 }
-.alertify-button-cancel { background-color: #df7c72 }
+.alertify-button-cancel {
+    background: #d96357;
+    background: rgba(217, 99, 87, 0.85);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#D9D96357,endColorstr=#D9D96357);
+}
 .alertify-button-cancel:hover, .alertify-button-cancel:active, .alertify-button-cancel:focus { background-color: #c0392b }

--- a/themes/alertify.default.css
+++ b/themes/alertify.default.css
@@ -2,76 +2,63 @@
  * Default Look and Feel
  */
 .alertify {
-    font-family: sans-serif;
-    background: #FFF;
-    background: rgba( 255, 255, 255, .95 );
-    color: #02070B;
+    color: #eeeeee;
     text-align: center;
-    border: 1px solid #EAEAEA;
+    font-family: sans-serif;
 }
-    .alertify-body {
-    }
-        .alertify-title {
-            margin: 0 0 1em;
-            padding: 2em 2em 1em;
-        }
-
-    .alertify-input {
-        background: rgba( 250, 250, 250, .8 );
-        font-size: 100%;
-        line-height: 1.5;
-        outline: none;
-        border: none;
-        border-top: 1px solid #EAEAEA;
-        width: 100%;
-        padding: 1em;
-        margin: 0;
-        box-sizing: border-box;
-    }
-
-    .alertify-buttons {
-        position: relative;
-        overflow: hidden;
-        border-top: 1px solid #EAEAEA;
-    }
-        .alertify-buttons:after {
-            content: "";
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            left: 50%;
-            border-left: 1px solid #EAEAEA;
-        }
-        .alertify--alert .alertify-buttons:after {
-            display: none;
-        }
-
-    .alertify-button {
-        float: left;
-        display: inline;
-        width: 50%;
-        color: #02070B;
-        padding: 1em 0;
-        box-sizing: border-box;
-        -webkit-transition: background-color .3s ease-out;
-           -moz-transition: background-color .3s ease-out;
-                transition: background-color .3s ease-out;
-    }
-
-        .alertify--alert .alertify-button {
-            width: 100%;
-        }
-
-        .alertify-button:hover,
-        .alertify-button:focus {
-            outline: none;
-            background-color: #FAFAFA;
-        }
-        .alertify-button:active {
-            background-color: #F1F1F1;
-        }
-
-    .alertify-button-ok {
-        color: #498FFF;
-        font-weight: bold;
-    }
+.alertify-body {
+    background: #ecf0f1;
+    background: rgba(236, 240, 241, 0.9);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#E6ECF0F1,endColorstr=#E6ECF0F1);
+}
+.alertify-title {
+    background: #34495e;
+    background: rgba(52, 73, 94, 0.9);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#E634495E,endColorstr=#E634495E);
+    margin: 0;
+    padding: 2em;
+    font-size: 1.1em;
+}
+.alertify-input {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    -webkit-transition: all 0.3s ease-out;
+    -moz-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    margin: 0;
+    padding: 1em;
+    width: 100%;
+    outline: none;
+    border: 2px solid #bdc3c7;
+    color: #999999;
+    font-size: 100%;
+    line-height: 1.5;
+}
+.alertify-input:hover, .alertify-input:active, .alertify-input:focus { border: 2px solid #7f8c8d }
+.alertify-input:active, .alertify-input:focus { color: #333333 }
+.alertify-buttons { *zoom: 1 }
+.alertify-buttons:before, .alertify-buttons:after {
+    display: table;
+    content: "";
+}
+.alertify-buttons:after { clear: both }
+.alertify--alert .alertify-button { width: 100% }
+.alertify-button {
+    -webkit-transition: background-color 0.3s ease-out, color 0.3s ease-out;
+    -moz-transition: background-color 0.3s ease-out, color 0.3s ease-out;
+    transition: background-color 0.3s ease-out, color 0.3s ease-out;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    float: left;
+    padding: 1em 0;
+    width: 50%;
+    font-weight: bold;
+}
+.alertify-button:focus { outline: none }
+.alertify-button-ok, .alertify-button-cancel { color: #eeeeee }
+.alertify-button-ok { background-color: #60db94 }
+.alertify-button-ok:hover, .alertify-button-ok:active, .alertify-button-ok:focus { background-color: #27ae60 }
+.alertify-button-cancel { background-color: #df7c72 }
+.alertify-button-cancel:hover, .alertify-button-cancel:active, .alertify-button-cancel:focus { background-color: #c0392b }


### PR DESCRIPTION
https://github.com/fabien-d/alertify.js/issues/187 : submit a base theme;

revised top-level .alertify rules and moved background rules to its children;

removed border styling except for input element; perhaps bump up the border width from 2px to 3px to really make it look like a text input

revised .alertify-buttons to use avoid using position styles;
added color palette for button-cancel and button-ok;

revised .alertify-title to override default margins inherited from p elements and bumped up its font-size slightly to attract more attention to the message;

added vendor prefixes for box-sizing; added IE fallback for backgrounds with opacity;

removed .alertify--alert .alertify-buttons:after rule because of .alertify-buttons revisions;

added box-shadow to alertify-body;

added consistent background alpha settings for alertify-body's children elements

![screen shot 2014-01-26 at 4 29 31 am](https://f.cloud.github.com/assets/5248913/2003762/ca5f4402-8674-11e3-9e30-70640bf0dca0.png)

![screen shot 2014-01-26 at 4 28 38 am](https://f.cloud.github.com/assets/5248913/2003761/ca4ddd20-8674-11e3-80b8-e5661a84d1c0.png)

![screen shot 2014-01-26 at 4 33 48 am](https://f.cloud.github.com/assets/5248913/2003770/8c1c8c4e-8675-11e3-96f9-6af34058b804.png)

![screen shot 2014-01-26 at 4 32 32 am](https://f.cloud.github.com/assets/5248913/2003769/8c1b0b44-8675-11e3-9067-31dc15e4d986.png)

![screen shot 2014-01-26 at 4 34 37 am](https://f.cloud.github.com/assets/5248913/2003772/8c1d65a6-8675-11e3-8aba-b82b45bec104.png)

![screen shot 2014-01-26 at 4 32 51 am](https://f.cloud.github.com/assets/5248913/2003771/8c1d07b4-8675-11e3-8cbb-31df2dd52bb0.png)
