### PR TITLE
Ensure .alertify-logs shrink-wraps contents

### DIFF
--- a/themes/alertify.core.css
+++ b/themes/alertify.core.css
@@ -55,7 +55,7 @@
 .alertify-logs {
 	position: fixed;
 	z-index: 5000;
-	bottom: 10px;
+	bottom: inherit;
 	right: 10px;
 	width: 300px;
 }


### PR DESCRIPTION
Avoids blocking click events below log windows

Re: #209

CSS seems to clearly extend to almost bottom of page. Were you unable to reproduce in another version?
