### PR TITLE
Prevent restoring focus to last element if none exist

### DIFF
--- a/src/alertify.js
+++ b/src/alertify.js
@@ -419,7 +419,9 @@
 					elCover.className  = "alertify-cover alertify-cover-hidden";
 					// set focus to the last element or body
 					// after the dialog is closed
-					elCallee ? elCallee.focus() : null;
+					if (elCallee) {
+						elCallee.focus();	
+					}
 				}
 			},
 

--- a/src/alertify.js
+++ b/src/alertify.js
@@ -419,7 +419,7 @@
 					elCover.className  = "alertify-cover alertify-cover-hidden";
 					// set focus to the last element or body
 					// after the dialog is closed
-					elCallee.focus();
+					elCallee ? elCallee.focus() : null;
 				}
 			},
 


### PR DESCRIPTION
Fixed a null pointer exception when trying to restore focus to the last element where that element doesn't exist.
