### PR TITLE
Fix SPACE key handling

### DIFF
--- a/src/alertify.js
+++ b/src/alertify.js
@@ -158,7 +158,7 @@
 				// keyup handler
 				key = function (event) {
 					var keyCode = event.keyCode;
-					if ((keyCode === keys.SPACE && !hasInput) || (hasInput && keyCode === keys.ENTER)) ok(event);
+					if (hasInput && keyCode === keys.ENTER) ok(event);
 					if (keyCode === keys.ESC && hasCancel) cancel(event);
 				};
 


### PR DESCRIPTION
The button's onclick event will fire both for mouse clicks and when the space key is pressed while the button has focus.

**Test case**:
Open a confirm dialog then tab to focus the **Cancel** button then press space key, the **Ok** event will be triggered.

Issue #12 is no longer valid, as PR #33 maintains tab focus inside the dialog until an action happens. 
