### PR TITLE
Working with webpack

### DIFF
--- a/src/alertify.js
+++ b/src/alertify.js
@@ -623,4 +623,4 @@
 		global.alertify = new Alertify();
 	}
 
-}(this));
+}(window));


### PR DESCRIPTION
Hi, I have been using Alertify with Webpack for a while, and I always had changed:
Line 626 from:

```
(this));
```

To: 

```
(window));
```

Works normally with this change even when not using webpack (Though I have not extensively used it outside of Webpack, but it seems to work perfectly). 

Just thought I'd drop the pull request so this line does not have to be changed every time it's installed via NPM for Webpack users. 

If you don't want this, its OK, just thought I'd make a suggestion. 

Thanks!
